### PR TITLE
Fix incorrect import in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -27,7 +27,7 @@ Usage:
 
 ::
 
-  import sshpubkeys
+  from sshpubkeys import SSHKey
   ssh = SSHKey("ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAAYQCxO38tKAJXIs9ivPxt7AY"
         "dfybgtAR1ow3Qkb9GPQ6wkFHQqcFDe6faKCxH6iDRteo4D8L8B"
         "xwzN42uZSB0nfmjkIxFTcEU3mFSXEbWByg78aoddMrAAjatyrh"


### PR DESCRIPTION
sshpubkeys is imported instead of SSHKey so users who follow the example would get NameError: name 'SSHKey' is not defined.