### PR TITLE
ecdsa: check for AssertionError

### DIFF
--- a/sshpubkeys/__init__.py
+++ b/sshpubkeys/__init__.py
@@ -161,8 +161,10 @@ class SSHKey(object):
             curve, hash_algorithm = curve_data[curve_information]
 
             data = self.unpack_by_int()
-
-            ecdsa_key = ecdsa.VerifyingKey.from_string(data[1:], curve, hash_algorithm)
+            try:
+                ecdsa_key = ecdsa.VerifyingKey.from_string(data[1:], curve, hash_algorithm)
+            except AssertionError:
+                raise InvalidKeyException("Invalid ecdsa key")  
             self.bits = int(curve_information.replace(b"nistp", b"")) # TODO
             self.ecdsa = ecdsa_key
         elif self.key_type == b"ssh-ed25519":

--- a/tests/invalid_keys.py
+++ b/tests/invalid_keys.py
@@ -11,6 +11,8 @@ keys = [
  ["ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAH0GODBKRjsFB/1v3pDRGpA6xR+QpOJg9vat0brlbUNA=", TooShortKeyException, "too_short_ed25519"],
  ["ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIUGODBKRjsFB/1v3pDRGpA6xR+QpOJg9vat0brlbUNDDpA==", TooLongKeyException, "too_long_ed25519"],
 
+ ["ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBE2gqbAChP2h3fTPx3Jy2KdOJUiBGEiqBUwoosfzllw+KrqmGiDEWlufSxdiSOFuLd4a8PSwhoWbdQgRVFrZAvFE=", InvalidKeyException, "invalid_ecdsa_key"],
+
  ["ecdsa-sha2-nistp255 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTUAAAAIbmlzdHAyNTUAAABBBE2gqbAChP2h3fTPx3Jy2KdOJUiBGEiqBUwoosfzllw+KrqmGiDEWlufSxdiSOFuLd4a8PSwhoWbdQRVFrZAvFE=", NotImplementedError, "invalid_nist_curve"],
  ["", InvalidKeyException, "empty_key"],
  ["- -", MalformedDataException, "no_content"],


### PR DESCRIPTION
ecdsaVerifyingKey.from_string can raise AssertionError if the key is
invalid.