### PR TITLE
Add an argument to disable options

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,11 @@ language: python
 python:
   - "2.6"
   - "2.7"
-  - "3.2"
   - "3.3"
   - "3.4"
   - "3.5"
   - "3.5-dev"
   - "nightly"
   - "pypy"
-  - "pypy3"
 install: "pip install -r requirements.txt"
 script: "python setup.py test"

--- a/README.rst
+++ b/README.rst
@@ -55,6 +55,8 @@ Set options in constructor as a keywords (i.e., `SSHKey(None, strict_mode=False)
 
 - strict_mode: defaults to True. Disallows keys OpenSSH's ssh-keygen refuses to create. For instance, this includes DSA keys where length != 1024 bits and RSA keys shorter than 1024-bit. If set to False, tries to allow all keys OpenSSH accepts, including highly insecure 1-bit DSA keys.
 - skip_option_parsing: if set to True, options string is not parsed (ssh.options_raw is populated, but ssh.options is not).
+- disallow_options: if set to True, options are not allowed and it will raise an
+  InvalidOptionsError.
 
 Exceptions
 ----------

--- a/sshpubkeys/keys.py
+++ b/sshpubkeys/keys.py
@@ -104,6 +104,7 @@ class SSHKey(object):  # pylint:disable=too-many-instance-attributes
         self.key_type = None
         self.strict_mode = bool(kwargs.get("strict", True))
         self.skip_option_parsing = bool(kwargs.get("skip_option_parsing", False))
+        self.disallow_options = bool(kwargs.get("disallow_options", False))
         if keydata:
             try:
                 self.parse(keydata)
@@ -414,3 +415,6 @@ class SSHKey(object):  # pylint:disable=too-many-instance-attributes
 
         if current_position != len(self._decoded_key):
             raise MalformedDataError("Leftover data: %s bytes" % (len(self._decoded_key) - current_position))
+
+        if self.disallow_options and self.options:
+            raise InvalidOptionsError("Options are disabled.")

--- a/sshpubkeys/keys.py
+++ b/sshpubkeys/keys.py
@@ -417,4 +417,4 @@ class SSHKey(object):  # pylint:disable=too-many-instance-attributes
             raise MalformedDataError("Leftover data: %s bytes" % (len(self._decoded_key) - current_position))
 
         if self.disallow_options and self.options:
-            raise InvalidOptionsError("Options are disabled.")
+            raise InvalidOptionsError("Options are disallowed.")


### PR DESCRIPTION
This PR allows to disable the presence of options in an ssh key, in order to avoid command injections for one of my programs.