### PR TITLE
support PyCryptodome sizing functions

### DIFF
--- a/sshpubkeys/keys.py
+++ b/sshpubkeys/keys.py
@@ -279,7 +279,11 @@ class SSHKey(object):  # pylint:disable=too-many-instance-attributes
         unpacked_n = self._parse_long(raw_n)
 
         self.rsa = RSA.construct((unpacked_n, unpacked_e))
-        self.bits = self.rsa.size() + 1
+
+        try:
+            self.bits = self.rsa.size() + 1
+        except TypeError:
+            self.bits = self.rsa.size_in_bits()
 
         if self.strict_mode:
             min_length = self.RSA_MIN_LENGTH_STRICT


### PR DESCRIPTION
first try stdlib `Crypto _{R,D}SAObj.size()`, then fall back to the
PyCryptodome `size_in_bites()` method.

helpful standalone, and also necessary for PR https://github.com/ojarva/python-sshpubkeys/pull/32. alternatively, the project can move to a tox testing framework and support both libraries side by side.

note that this will also need support here: [sshpubkeys/keys.py#L305](https://github.com/majuscule/python-sshpubkeys/blob/master/sshpubkeys/keys.py#L305), but DSA sizing is currently unsupported by PyCryptodome. I have added support in PR https://github.com/Legrandin/pycryptodome/pull/94, and will submit a new PR here if merged and released.