### PR TITLE
Adjust valid min length for RSA keys

### DIFF
--- a/sshpubkeys/keys.py
+++ b/sshpubkeys/keys.py
@@ -57,7 +57,7 @@ class SSHKey(object):  # pylint:disable=too-many-instance-attributes
         b"nistp521": (ecdsa.curves.NIST521p, hashlib.sha512),
     }
 
-    RSA_MIN_LENGTH_STRICT = 1024
+    RSA_MIN_LENGTH_STRICT = 1023
     RSA_MAX_LENGTH_STRICT = 16384
     RSA_MIN_LENGTH_LOOSE = 768
     RSA_MAX_LENGTH_LOOSE = 16384


### PR DESCRIPTION
Well a key lenght of 1023 is still valid key... 

https://the.earth.li/~sgtatham/putty/0.60/htmldoc/Chapter8.html under 8.2.3

