### PR TITLE
fix AuthorizedKeysFile example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -65,15 +65,11 @@ Parsing of `authorized_keys` files:
 ::
 
   from sshpubkeys import AuthorizedKeysFile
+  f = open("/home/username/.ssh/authorized_keys", "r")
+  key_file = AuthorizedKeysFile(f, strict=False)
 
-  key_file = AuthorizedKeysFile("""ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEGODBKRjsFB/1v3pDRGpA6xR+QpOJg9vat0brlbUNDD\n"""
-             """#This is a comment\n\n"""
-             """ecdsa-sha2-nistp521 AAAAE2VjZHNhLXNoYTItbmlzdHA1MjEAAAAIbmlzdHA1MjEAAACFBAF9QpvUneTvt8"""
-             """lu0ePSuzr7iLE9ZMPu2DFTmqh7BVn89IHuQ5dfg9pArxfHZWgu9lMdlOykVx0I6OXkE35A/mFqwwApyiPmiwno"""
-             """jmRnN//pApl6QQFINHzV/PGOSi599F1Y2tHQwcdb44CPOhkUmHtC9wKazSvw/ivbxNjcMzhhHsWGnA=="""
-             strict=True, disallow_options=True)
   for key in key_file.keys:
-      print(key.key_type, key.bits, key.hash_512())
+      print(key.key_type, key.bits, key.comment)
 
 
 Options


### PR DESCRIPTION
AuthorizedKeysFile example is wrong, AuthorizedKeysFile argument should be a file object (or a anything that can be iterated) not a string

Fixes #46 