### PR TITLE
Include LICENSE file in sdist tarball

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include README.rst
+include LICENSE.txt
 graft tests


### PR DESCRIPTION
the license should be distributed with the archive on pypi.