### PR TITLE
Replace ecdsa with PyCA/cryptography

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 cryptography==3.2
-ecdsa==0.13.3
 yapf==0.21.0

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     packages=["sshpubkeys"],
     test_suite="tests",
     python_requires='>=3',
-    install_requires=['cryptography>=2.1.4', 'ecdsa>=0.13'],
+    install_requires=['cryptography>=2.5'],
     extras_require={
         'dev': ['twine', 'wheel', 'yapf'],
     },

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -42,6 +42,14 @@ class TestKeys(unittest.TestCase):
         self.assertEqual(ssh.comment, comment)
         if fingerprint_sha256 is not None:
             self.assertEqual(ssh.hash_sha256(), fingerprint_sha256)
+        if ssh.ecdsa:
+            ec = ssh.ecdsa
+            repr(ec)
+            ec.to_pem()
+            ec.to_der()
+            ec.to_string("raw")
+            ec.to_string("uncompressed")
+            ec.to_string("compressed")
 
     def check_fail(self, pubkey, expected_error, **kwargs):
         """ Checks that key check raises specified exception """


### PR DESCRIPTION
Dependency on ecdsa is a problem for all applications and users that
have strict crypto requirements and do not permit custom implementations
of cryptographic algorithms. The package even warns that it is
potentially insecure and does not protect against side channel attacks.
It's less of an issue for pubkeys, but still a compliance issue.

Cryptography can handle ecdsa SSH keys without help of ecdsa Python
package. The PR replaces the key verification code. I have also included
a (mostly untested) re-implementation of ecdsa.key.VerifyingKey.

Signed-off-by: Christian Heimes <christian@python.org>