### PR TITLE
ed25516→ed25519

### DIFF
--- a/sshpubkeys/keys.py
+++ b/sshpubkeys/keys.py
@@ -425,8 +425,8 @@ class SSHKey:  # pylint:disable=too-many-instance-attributes
         self.ecdsa = _ECVerifyingKey(ecdsa_pubkey, hash_algorithm)
         return current_position
 
-    def _process_ed25516(self, data):
-        """Parses ed25516 keys.
+    def _process_ed25519(self, data):
+        """Parses ed25519 keys.
 
         There is no (apparent) way to validate ed25519 keys. This only
         checks data length (256 bits), but does not try to validate
@@ -465,7 +465,7 @@ class SSHKey:  # pylint:disable=too-many-instance-attributes
 
     def _process_sk_ed25519(self, data):
         """Parses sk_ed25519 public keys."""
-        current_position = self._process_ed25516(data)
+        current_position = self._process_ed25519(data)
         current_position, application = self._unpack_by_int(data, current_position)
         self._validate_application_string(application)
         return current_position
@@ -478,7 +478,7 @@ class SSHKey:  # pylint:disable=too-many-instance-attributes
         if self.key_type.strip().startswith(b"ecdsa-sha"):
             return self._process_ecdsa_sha(data)
         if self.key_type == b"ssh-ed25519":
-            return self._process_ed25516(data)
+            return self._process_ed25519(data)
         if self.key_type.strip().startswith(b"sk-ecdsa-sha"):
             return self._process_sk_ecdsa_sha(data)
         if self.key_type.strip().startswith(b"sk-ssh-ed25519"):

--- a/tests/valid_keys.py
+++ b/tests/valid_keys.py
@@ -199,24 +199,24 @@ keys = [[
     'joku@vps91201', 'ecdsa_sha2_nistp521', ["strict", "loose"]
 ], [
     'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEGODBKRjsFB/1v3pDRGpA6xR+QpOJg9vat0brlbUNDD', 256,
-    'MD5:76:85:77:0d:24:6c:1e:d3:23:c4:29:92:80:f9:fb:94', 'SHA256:uG85B9hYCFenm0DxEo3PRzypYRY3kSa7veE/KbSSau0', 'ed25516_1',
+    'MD5:76:85:77:0d:24:6c:1e:d3:23:c4:29:92:80:f9:fb:94', 'SHA256:uG85B9hYCFenm0DxEo3PRzypYRY3kSa7veE/KbSSau0', 'ed25519_1',
     ["strict", "loose"]
 ], [
     'command="/bin/ls",no-agent-forwarding,no-user-rc ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEGODBKRjsFB/1v3pDRGpA6xR+QpOJg9vat0brlbUNDD',
     256, 'MD5:76:85:77:0d:24:6c:1e:d3:23:c4:29:92:80:f9:fb:94', 'SHA256:uG85B9hYCFenm0DxEo3PRzypYRY3kSa7veE/KbSSau0',
-    'command="/bin/ls",no-agent-forwarding,no-user-rc', None, 'ed25516_with_command_1', ["strict", "loose"]
+    'command="/bin/ls",no-agent-forwarding,no-user-rc', None, 'ed25519_with_command_1', ["strict", "loose"]
 ], [
     'command="/bin/ls",no-agent-forwarding,no-user-rc ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEGODBKRjsFB/1v3pDRGpA6xR+QpOJg9vat0brlbUNDD random comment for this key',
     256, 'MD5:76:85:77:0d:24:6c:1e:d3:23:c4:29:92:80:f9:fb:94', 'SHA256:uG85B9hYCFenm0DxEo3PRzypYRY3kSa7veE/KbSSau0',
-    'command="/bin/ls",no-agent-forwarding,no-user-rc', 'random comment for this key', 'ed25516_with_command_2',
+    'command="/bin/ls",no-agent-forwarding,no-user-rc', 'random comment for this key', 'ed25519_with_command_2',
     ["strict", "loose"]
 ], [
     'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEGODBKRjsFB/1v3pDRGpA6xR+QpOJg9vat0brlbUNDD random comment for this key', 256,
     'MD5:76:85:77:0d:24:6c:1e:d3:23:c4:29:92:80:f9:fb:94', 'SHA256:uG85B9hYCFenm0DxEo3PRzypYRY3kSa7veE/KbSSau0', None,
-    "random comment for this key", 'ed25516_with_command_3', ["strict", "loose"]
+    "random comment for this key", 'ed25519_with_command_3', ["strict", "loose"]
 ], [
     'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIL5x8+1ucT6+AKQIW8u5W/FOuBvWx2fCQlSLkUakry89', 256,
-    'MD5:0c:4e:13:0f:f3:ab:20:58:85:2e:79:9b:0f:2b:43:c8', 'SHA256:2ao9ds3IIkmXiLPRMs/47HIkHIV/qxzEHKW8p9lhRYA', "ed25516_2",
+    'MD5:0c:4e:13:0f:f3:ab:20:58:85:2e:79:9b:0f:2b:43:c8', 'SHA256:2ao9ds3IIkmXiLPRMs/47HIkHIV/qxzEHKW8p9lhRYA', "ed25519_2",
     ["strict", "loose"]
 ], [
     'sk-ecdsa-sha2-nistp256@openssh.com AAAAInNrLWVjZHNhLXNoYTItbmlzdHAyNTZAb3BlbnNzaC5jb20AAAAIbmlzdHAyNTYAAABBBGdtNJ7nNTVW3kXvrWpvTENCfetzI2yUb8m5WLB2kcOVqF+3orTmloZsQEt1K386hlaqNzm7MVB+xcAiNoqhiI4AAAAEc3NoOg==',


### PR DESCRIPTION
Note: This is direct output from `rgr 25516 -R 25519`:
<https://github.com/ElectricRCAircraftGuy/eRCaGuy_dotfiles/blob/master/useful_scripts/rg_replace.sh>

Further note: I ran your tests but am not a user of this library. I came across it because someone I know made the same "typo" (it's actually more of a misreading/misremembering of a typo, typo is a bit face-saving hehe but sure, he made a typo, why not) and I wanted to know if it was an alternate algorithm and your library confused matters a bit due to the fact it even appears in your tests, and repeatedly in source, I could not tell. :bow: 

Closes #88.