### PR TITLE
Avoid deprecated encode_point() method

### DIFF
--- a/sshpubkeys/keys.py
+++ b/sshpubkeys/keys.py
@@ -57,9 +57,10 @@ class _ECVerifyingKey:
     def to_string(self, encoding="raw"):
         """Pub key as bytes string"""
         if encoding == "raw":
-            return self.pubkey.public_numbers().encode_point()[1:]
+            # Omit first char because it is an unwanted '\x04'
+            return self.pubkey.public_bytes(Encoding.OpenSSH, PublicFormat.OpenSSH)[1:]
         if encoding == "uncompressed":
-            return self.pubkey.public_numbers().encode_point()
+            return self.pubkey.public_bytes(Encoding.X962, PublicFormat.UncompressedPoint)
         if encoding == "compressed":
             return self.pubkey.public_bytes(Encoding.X962, PublicFormat.CompressedPoint)
         raise ValueError(encoding)


### PR DESCRIPTION
- This allows `python-sshpubkeys` to work with `cryptography>=39.0.0`.
- `ec.EllipticCurvePublicNumbers.encode_point()` had been deprecated for a long time, and was removed in commit pyca/cryptography@2b6e463 , or `cryptography==39.0.0`.
- I manually tested to confirm that for all of the existing test cases that called `to_string()`, this new `public_bytes()` method yielded the same bytes as the old `encode_point()`.
- Since the "compressed" `to_string()` was already using `public_bytes()` with `Encoding` and `PublicFormat`, it seems unlikely that this change will break support for any versions of `cryptography`


## Pending question about test cases
All of the unit tests still pass with `python -m unittest tests`.

I was unsure whether I should try adding unit tests for these `to_string()` methods or not. Since I'm not super familiar with cryptography, I would simply have based any expected values off of whatever was already being produced by the `to_string()` methods. I don't think is the best way of writing tests. But, this would also at least guarantee that any future changes do not *change* the output of `to_string()`, so perhaps it is still worth it?